### PR TITLE
fixed compute TCK checksum

### DIFF
--- a/parseATR/parseATR.py
+++ b/parseATR/parseATR.py
@@ -1039,12 +1039,10 @@ def compute_tck(atr):
     Returns:
         TCK value
     """
-    # do not include TS byte
-    s = atr["atr"][0]
-    for e in atr["atr"]:
+    # do not include TS byte and TCK byte
+    s = 0
+    for e in atr["atr"][1:-1]:
         s ^= e
-    # remove TCK
-    s ^= atr["atr"][-1]
     return s
 
 


### PR DESCRIPTION
`3B F8 13 00 00 81 31 FE 45 4A 43 4F 50 76 32 34 31 B7` 
The `computer_tck` function doesn't compute the correct TCK of this ATR.
