### PR TITLE
Fix parsing of the second software function table (data coding byte)

### DIFF
--- a/parseATR/parseATR.py
+++ b/parseATR/parseATR.py
@@ -654,7 +654,7 @@ def data_coding(dc):
     text.append(t[v])
 
     text.append("        - Value 'FF' for the first byte of BER-TLV tag fields: ")
-    if dc & 16:
+    if (dc & 16) == 0:
         text.append("in")
     text.append("valid\n")
 


### PR DESCRIPTION
Data coding byte (in historical bytes: tag 7, byte 2, bit 5) indicates 'FF' as valid first byte of a BER-TLV tag field if =1 not =0, based on ISO 7816-4:2020 p.123 sec.12.2.2.9 table.126.